### PR TITLE
Add Kung-Fu Master Alternatives

### DIFF
--- a/_alternatives/_Kung-Fu Master/Kung-Fu Master (bootleg set 1).mra
+++ b/_alternatives/_Kung-Fu Master/Kung-Fu Master (bootleg set 1).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
-	<name>Kung-Fu Master (World)</name>
+	<name>Kung-Fu Master (bootleg set 1)</name>
 	<mameversion>0221</mameversion>
-	<setname>kungfum</setname>
+	<setname>kungfub</setname>
 	<mratimestamp>20200601015747</mratimestamp>
 	<year>1984</year>
 	<manufacturer>Irem</manufacturer>
@@ -25,7 +25,7 @@
 	<rom index="1">
 		<part>04</part>
 	</rom>
-	<rom index="0" zip="kungfum.zip" md5="none">
+	<rom index="0" zip="kungfum.zip|kungfub.zip" type="merged|nonmerged|split" md5="none">
 		<part crc="5d8e791d" name="c5.5h"/>
 		<part crc="4000e2b8" name="c4.5k"/>
 		<part crc="5d8e791d" name="c5.5h"/>

--- a/_alternatives/_Kung-Fu Master/Kung-Fu Master (bootleg set 1).mra
+++ b/_alternatives/_Kung-Fu Master/Kung-Fu Master (bootleg set 1).mra
@@ -1,0 +1,134 @@
+<misterromdescription>
+	<name>Kung-Fu Master (World)</name>
+	<mameversion>0221</mameversion>
+	<setname>kungfum</setname>
+	<mratimestamp>20200601015747</mratimestamp>
+	<year>1984</year>
+	<manufacturer>Irem</manufacturer>
+	<category>Fighter / Asian</category>
+	<rbf>iremm62</rbf>
+        <buttons names="Kick,Punch,Start 1P,Start 2P,Coin,Pause" default="A,B,Start,Select,R,L"/>
+	<switches default="FF,FD">
+		<dip bits="0" name="Difficulty" ids="Hard,Easy"></dip>
+		<dip bits="1" name="Energy Loss" ids="Fast,Slow"></dip>
+		<dip bits="2,3" name="Lives" ids="5,4,2,3"></dip>
+        <dip bits="4,7" name="Coinage" ids="Free Play,1C/1C" values="16,15"></dip>
+		<dip bits="8" name="Flip Screen" ids="On,Off"></dip>
+		<dip bits="9" name="Cabinet" ids="Upright,Cocktail"></dip>
+		<dip bits="10" name="Coin Mode" ids="Mode 2,Mode 1"></dip>
+		<dip bits="11" name="Slow Motion Mode (Cheat)" ids="On,Off"></dip>
+		<dip bits="12" name="Freeze (Cheat)" ids="On,Off"></dip>
+		<dip bits="13" name="Level Selection (Cheat)" ids="On,Off"></dip>
+		<dip bits="14" name="Invulnerability (Cheat)" ids="On,Off"></dip>
+		<dip bits="15" name="Service Mode" ids="On,Off"></dip>
+	</switches>
+	<rom index="1">
+		<part>04</part>
+	</rom>
+	<rom index="0" zip="kungfum.zip" md5="none">
+		<part crc="5d8e791d" name="c5.5h"/>
+		<part crc="4000e2b8" name="c4.5k"/>
+		<part crc="5d8e791d" name="c5.5h"/>
+		<part crc="4000e2b8" name="c4.5k"/>
+		<part crc="5d8e791d" name="c5.5h"/>
+		<part crc="4000e2b8" name="c4.5k"/>
+		<part crc="5d8e791d" name="c5.5h"/>
+		<part crc="4000e2b8" name="c4.5k"/>
+		<part repeat="0xa000">FF</part>
+		<part crc="58e87ab0" name="a-3e-.bin"/>
+		<part crc="c81e31ea" name="a-3f-.bin"/>
+		<part crc="d99fb995" name="a-3h-.bin"/>
+		<interleave output="32">
+			<part crc="6b2cc9c8" name="g-4c-a.bin" map="0001"/>
+			<part crc="c648f558" name="g-4d-a.bin" map="0010"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="0100"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="6b2cc9c8" name="g-4c-a.bin" map="0001"/>
+			<part crc="c648f558" name="g-4d-a.bin" map="0010"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="0100"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="6b2cc9c8" name="g-4c-a.bin" map="0001"/>
+			<part crc="c648f558" name="g-4d-a.bin" map="0010"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="0100"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="6b2cc9c8" name="g-4c-a.bin" map="0001"/>
+			<part crc="c648f558" name="g-4d-a.bin" map="0010"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="0100"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="16fb5150" name="b-4k-.bin" map="0001"/>
+			<part crc="28a213aa" name="b-3n-.bin" map="0010"/>
+			<part crc="01298885" name="b-4c-.bin" map="0100"/>
+			<part crc="01298885" name="b-4c-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="67745a33" name="b-4f-.bin" map="0001"/>
+			<part crc="d5228df3" name="b-4n-.bin" map="0010"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="0100"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="bd1c2261" name="b-4l-.bin" map="0001"/>
+			<part crc="b16de4f2" name="b-4m-.bin" map="0010"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="0100"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8ac5ed3a" name="b-4h-.bin" map="0001"/>
+			<part crc="eba0d66b" name="b-3m-.bin" map="0010"/>
+			<part crc="6189d626" name="b-4a-.bin" map="0100"/>
+			<part crc="6189d626" name="b-4a-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="16fb5150" name="b-4k-.bin" map="0001"/>
+			<part crc="28a213aa" name="b-3n-.bin" map="0010"/>
+			<part crc="01298885" name="b-4c-.bin" map="0100"/>
+			<part crc="01298885" name="b-4c-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="67745a33" name="b-4f-.bin" map="0001"/>
+			<part crc="d5228df3" name="b-4n-.bin" map="0010"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="0100"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="bd1c2261" name="b-4l-.bin" map="0001"/>
+			<part crc="b16de4f2" name="b-4m-.bin" map="0010"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="0100"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8ac5ed3a" name="b-4h-.bin" map="0001"/>
+			<part crc="eba0d66b" name="b-3m-.bin" map="0010"/>
+			<part crc="6189d626" name="b-4a-.bin" map="0100"/>
+			<part crc="6189d626" name="b-4a-.bin" map="1000"/>
+		</interleave>
+		<part repeat="0x10000">FF</part>
+		<part crc="76c05a9c" name="tbp24s10-gfx-1r.bin"/>
+		<part crc="23f06b99" name="tbp24s10-gfx-1s.bin"/>
+		<part crc="35e45021" name="tbp24s10-gfx-1p.bin"/>
+		<part crc="668e6bca" name="tbp24s10-main-1c.bin"/>
+		<part crc="964b6495" name="tbp24s10-main-1a.bin"/>
+		<part crc="550563e1" name="tbp24s10-main-1b.bin"/>
+		<part repeat="0x300">FF</part>
+		<part crc="7a601c3d" name="18s030-gfx-8t.bin"/>
+	</rom>
+
+	<rom index="3" md5="none">
+		<part>
+		00 00 FF FF 00 3F 00 02 00 02 00 01 00 FF 00 00
+		00 00 EA 06 00 78 00 41
+		00 00 E9 80 00 03 52 00
+		</part>
+	</rom>
+	<nvram index="4" size="123"/>	
+
+
+</misterromdescription>

--- a/_alternatives/_Kung-Fu Master/Kung-Fu Master (bootleg set 2).mra
+++ b/_alternatives/_Kung-Fu Master/Kung-Fu Master (bootleg set 2).mra
@@ -1,0 +1,134 @@
+<misterromdescription>
+	<name>Kung-Fu Master (World)</name>
+	<mameversion>0221</mameversion>
+	<setname>kungfum</setname>
+	<mratimestamp>20200601015747</mratimestamp>
+	<year>1984</year>
+	<manufacturer>Irem</manufacturer>
+	<category>Fighter / Asian</category>
+	<rbf>iremm62</rbf>
+        <buttons names="Kick,Punch,Start 1P,Start 2P,Coin,Pause" default="A,B,Start,Select,R,L"/>
+	<switches default="FF,FD">
+		<dip bits="0" name="Difficulty" ids="Hard,Easy"></dip>
+		<dip bits="1" name="Energy Loss" ids="Fast,Slow"></dip>
+		<dip bits="2,3" name="Lives" ids="5,4,2,3"></dip>
+        <dip bits="4,7" name="Coinage" ids="Free Play,1C/1C" values="16,15"></dip>
+		<dip bits="8" name="Flip Screen" ids="On,Off"></dip>
+		<dip bits="9" name="Cabinet" ids="Upright,Cocktail"></dip>
+		<dip bits="10" name="Coin Mode" ids="Mode 2,Mode 1"></dip>
+		<dip bits="11" name="Slow Motion Mode (Cheat)" ids="On,Off"></dip>
+		<dip bits="12" name="Freeze (Cheat)" ids="On,Off"></dip>
+		<dip bits="13" name="Level Selection (Cheat)" ids="On,Off"></dip>
+		<dip bits="14" name="Invulnerability (Cheat)" ids="On,Off"></dip>
+		<dip bits="15" name="Service Mode" ids="On,Off"></dip>
+	</switches>
+	<rom index="1">
+		<part>04</part>
+	</rom>
+	<rom index="0" zip="kungfum.zip" md5="none">
+		<part crc="3f65313f" name="kf4"/>
+		<part crc="9ea325f3" name="kf5"/>
+		<part crc="3f65313f" name="kf4"/>
+		<part crc="9ea325f3" name="kf5"/>
+		<part crc="3f65313f" name="kf4"/>
+		<part crc="9ea325f3" name="kf5"/>
+		<part crc="3f65313f" name="kf4"/>
+		<part crc="9ea325f3" name="kf5"/>
+		<part repeat="0xa000">FF</part>
+		<part crc="58e87ab0" name="a-3e-.bin"/>
+		<part crc="c81e31ea" name="a-3f-.bin"/>
+		<part crc="d99fb995" name="a-3h-.bin"/>
+		<interleave output="32">
+			<part crc="6b2cc9c8" name="g-4c-a.bin" map="0001"/>
+			<part crc="c648f558" name="g-4d-a.bin" map="0010"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="0100"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="6b2cc9c8" name="g-4c-a.bin" map="0001"/>
+			<part crc="c648f558" name="g-4d-a.bin" map="0010"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="0100"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="6b2cc9c8" name="g-4c-a.bin" map="0001"/>
+			<part crc="c648f558" name="g-4d-a.bin" map="0010"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="0100"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="6b2cc9c8" name="g-4c-a.bin" map="0001"/>
+			<part crc="c648f558" name="g-4d-a.bin" map="0010"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="0100"/>
+			<part crc="fbe9276e" name="g-4e-a.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="16fb5150" name="b-4k-.bin" map="0001"/>
+			<part crc="28a213aa" name="b-3n-.bin" map="0010"/>
+			<part crc="01298885" name="b-4c-.bin" map="0100"/>
+			<part crc="01298885" name="b-4c-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="67745a33" name="b-4f-.bin" map="0001"/>
+			<part crc="d5228df3" name="b-4n-.bin" map="0010"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="0100"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="bd1c2261" name="b-4l-.bin" map="0001"/>
+			<part crc="b16de4f2" name="b-4m-.bin" map="0010"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="0100"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8ac5ed3a" name="b-4h-.bin" map="0001"/>
+			<part crc="eba0d66b" name="b-3m-.bin" map="0010"/>
+			<part crc="6189d626" name="b-4a-.bin" map="0100"/>
+			<part crc="6189d626" name="b-4a-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="16fb5150" name="b-4k-.bin" map="0001"/>
+			<part crc="28a213aa" name="b-3n-.bin" map="0010"/>
+			<part crc="01298885" name="b-4c-.bin" map="0100"/>
+			<part crc="01298885" name="b-4c-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="67745a33" name="b-4f-.bin" map="0001"/>
+			<part crc="d5228df3" name="b-4n-.bin" map="0010"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="0100"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="bd1c2261" name="b-4l-.bin" map="0001"/>
+			<part crc="b16de4f2" name="b-4m-.bin" map="0010"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="0100"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8ac5ed3a" name="b-4h-.bin" map="0001"/>
+			<part crc="eba0d66b" name="b-3m-.bin" map="0010"/>
+			<part crc="6189d626" name="b-4a-.bin" map="0100"/>
+			<part crc="6189d626" name="b-4a-.bin" map="1000"/>
+		</interleave>
+		<part repeat="0x10000">FF</part>
+		<part crc="76c05a9c" name="b-1m-.bin"/>
+		<part crc="23f06b99" name="b-1n-.bin"/>
+		<part crc="35e45021" name="b-1l-.bin"/>
+		<part crc="668e6bca" name="g-1j-.bin"/>
+		<part crc="964b6495" name="g-1f-.bin"/>
+		<part crc="550563e1" name="g-1h-.bin"/>
+		<part repeat="0x300">FF</part>
+		<part crc="7a601c3d" name="b-5f-.bin"/>
+	</rom>
+
+	<rom index="3" md5="none">
+		<part>
+		00 00 FF FF 00 3F 00 02 00 02 00 01 00 FF 00 00
+		00 00 EA 06 00 78 00 41
+		00 00 E9 80 00 03 52 00
+		</part>
+	</rom>
+	<nvram index="4" size="123"/>	
+
+
+</misterromdescription>

--- a/_alternatives/_Kung-Fu Master/Kung-Fu Master (bootleg set 2).mra
+++ b/_alternatives/_Kung-Fu Master/Kung-Fu Master (bootleg set 2).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
-	<name>Kung-Fu Master (World)</name>
+	<name>Kung-Fu Master (bootleg set 2)</name>
 	<mameversion>0221</mameversion>
-	<setname>kungfum</setname>
+	<setname>kungfub2</setname>
 	<mratimestamp>20200601015747</mratimestamp>
 	<year>1984</year>
 	<manufacturer>Irem</manufacturer>
@@ -25,7 +25,7 @@
 	<rom index="1">
 		<part>04</part>
 	</rom>
-	<rom index="0" zip="kungfum.zip" md5="none">
+	<rom index="0" zip="kungfum.zip|kungfub2.zip" type="merged|nonmerged|split" md5="none">
 		<part crc="3f65313f" name="kf4"/>
 		<part crc="9ea325f3" name="kf5"/>
 		<part crc="3f65313f" name="kf4"/>

--- a/_alternatives/_Kung-Fu Master/Spartan X (Japan).mra
+++ b/_alternatives/_Kung-Fu Master/Spartan X (Japan).mra
@@ -1,0 +1,134 @@
+<misterromdescription>
+	<name>Kung-Fu Master (World)</name>
+	<mameversion>0221</mameversion>
+	<setname>kungfum</setname>
+	<mratimestamp>20200601015747</mratimestamp>
+	<year>1984</year>
+	<manufacturer>Irem</manufacturer>
+	<category>Fighter / Asian</category>
+	<rbf>iremm62</rbf>
+        <buttons names="Kick,Punch,Start 1P,Start 2P,Coin,Pause" default="A,B,Start,Select,R,L"/>
+	<switches default="FF,FD">
+		<dip bits="0" name="Difficulty" ids="Hard,Easy"></dip>
+		<dip bits="1" name="Energy Loss" ids="Fast,Slow"></dip>
+		<dip bits="2,3" name="Lives" ids="5,4,2,3"></dip>
+        <dip bits="4,7" name="Coinage" ids="Free Play,1C/1C" values="16,15"></dip>
+		<dip bits="8" name="Flip Screen" ids="On,Off"></dip>
+		<dip bits="9" name="Cabinet" ids="Upright,Cocktail"></dip>
+		<dip bits="10" name="Coin Mode" ids="Mode 2,Mode 1"></dip>
+		<dip bits="11" name="Slow Motion Mode (Cheat)" ids="On,Off"></dip>
+		<dip bits="12" name="Freeze (Cheat)" ids="On,Off"></dip>
+		<dip bits="13" name="Level Selection (Cheat)" ids="On,Off"></dip>
+		<dip bits="14" name="Invulnerability (Cheat)" ids="On,Off"></dip>
+		<dip bits="15" name="Service Mode" ids="On,Off"></dip>
+	</switches>
+	<rom index="1">
+		<part>04</part>
+	</rom>
+	<rom index="0" zip="kungfum.zip" md5="none">
+		<part crc="32a0a9a6" name="a-4e-c-j.bin"/>
+		<part crc="3173ea78" name="a-4d-c-j.bin"/>
+		<part crc="32a0a9a6" name="a-4e-c-j.bin"/>
+		<part crc="3173ea78" name="a-4d-c-j.bin"/>
+		<part crc="32a0a9a6" name="a-4e-c-j.bin"/>
+		<part crc="3173ea78" name="a-4d-c-j.bin"/>
+		<part crc="32a0a9a6" name="a-4e-c-j.bin"/>
+		<part crc="3173ea78" name="a-4d-c-j.bin"/>
+		<part repeat="0xa000">FF</part>
+		<part crc="58e87ab0" name="a-3e-.bin"/>
+		<part crc="c81e31ea" name="a-3f-.bin"/>
+		<part crc="d99fb995" name="a-3h-.bin"/>
+		<interleave output="32">
+			<part crc="8af9c5a6" name="g-4c-a-j.bin" map="0001"/>
+			<part crc="b8300c72" name="g-4d-a-j.bin" map="0010"/>
+			<part crc="b50429cd" name="g-4e-a-j.bin" map="0100"/>
+			<part crc="b50429cd" name="g-4e-a-j.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8af9c5a6" name="g-4c-a-j.bin" map="0001"/>
+			<part crc="b8300c72" name="g-4d-a-j.bin" map="0010"/>
+			<part crc="b50429cd" name="g-4e-a-j.bin" map="0100"/>
+			<part crc="b50429cd" name="g-4e-a-j.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8af9c5a6" name="g-4c-a-j.bin" map="0001"/>
+			<part crc="b8300c72" name="g-4d-a-j.bin" map="0010"/>
+			<part crc="b50429cd" name="g-4e-a-j.bin" map="0100"/>
+			<part crc="b50429cd" name="g-4e-a-j.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8af9c5a6" name="g-4c-a-j.bin" map="0001"/>
+			<part crc="b8300c72" name="g-4d-a-j.bin" map="0010"/>
+			<part crc="b50429cd" name="g-4e-a-j.bin" map="0100"/>
+			<part crc="b50429cd" name="g-4e-a-j.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="16fb5150" name="b-4k-.bin" map="0001"/>
+			<part crc="28a213aa" name="b-3n-.bin" map="0010"/>
+			<part crc="01298885" name="b-4c-.bin" map="0100"/>
+			<part crc="01298885" name="b-4c-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="67745a33" name="b-4f-.bin" map="0001"/>
+			<part crc="d5228df3" name="b-4n-.bin" map="0010"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="0100"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="bd1c2261" name="b-4l-.bin" map="0001"/>
+			<part crc="b16de4f2" name="b-4m-.bin" map="0010"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="0100"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8ac5ed3a" name="b-4h-.bin" map="0001"/>
+			<part crc="eba0d66b" name="b-3m-.bin" map="0010"/>
+			<part crc="6189d626" name="b-4a-.bin" map="0100"/>
+			<part crc="6189d626" name="b-4a-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="16fb5150" name="b-4k-.bin" map="0001"/>
+			<part crc="28a213aa" name="b-3n-.bin" map="0010"/>
+			<part crc="01298885" name="b-4c-.bin" map="0100"/>
+			<part crc="01298885" name="b-4c-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="67745a33" name="b-4f-.bin" map="0001"/>
+			<part crc="d5228df3" name="b-4n-.bin" map="0010"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="0100"/>
+			<part crc="c77b87d4" name="b-4e-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="bd1c2261" name="b-4l-.bin" map="0001"/>
+			<part crc="b16de4f2" name="b-4m-.bin" map="0010"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="0100"/>
+			<part crc="6a70615f" name="b-4d-.bin" map="1000"/>
+		</interleave>
+		<interleave output="32">
+			<part crc="8ac5ed3a" name="b-4h-.bin" map="0001"/>
+			<part crc="eba0d66b" name="b-3m-.bin" map="0010"/>
+			<part crc="6189d626" name="b-4a-.bin" map="0100"/>
+			<part crc="6189d626" name="b-4a-.bin" map="1000"/>
+		</interleave>
+		<part repeat="0x10000">FF</part>
+		<part crc="76c05a9c" name="b-1m-.bin"/>
+		<part crc="23f06b99" name="b-1n-.bin"/>
+		<part crc="35e45021" name="b-1l-.bin"/>
+		<part crc="668e6bca" name="g-1j-.bin"/>
+		<part crc="964b6495" name="g-1f-.bin"/>
+		<part crc="550563e1" name="g-1h-.bin"/>
+		<part repeat="0x300">FF</part>
+		<part crc="7a601c3d" name="b-5f-.bin"/>
+	</rom>
+
+	<rom index="3" md5="none">
+		<part>
+		00 00 FF FF 00 3F 00 02 00 02 00 01 00 FF 00 00
+		00 00 EA 06 00 78 00 41
+		00 00 E9 80 00 03 52 00
+		</part>
+	</rom>
+	<nvram index="4" size="123"/>	
+
+
+</misterromdescription>

--- a/_alternatives/_Kung-Fu Master/Spartan X (Japan).mra
+++ b/_alternatives/_Kung-Fu Master/Spartan X (Japan).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
-	<name>Kung-Fu Master (World)</name>
+	<name>Spartan X (Japan)</name>
 	<mameversion>0221</mameversion>
-	<setname>kungfum</setname>
+	<setname>spartanx</setname>
 	<mratimestamp>20200601015747</mratimestamp>
 	<year>1984</year>
 	<manufacturer>Irem</manufacturer>
@@ -25,7 +25,7 @@
 	<rom index="1">
 		<part>04</part>
 	</rom>
-	<rom index="0" zip="kungfum.zip" md5="none">
+	<rom index="0" zip="kungfum.zip|spartanx.zip" type="merged|nonmerged|split" md5="none">
 		<part crc="32a0a9a6" name="a-4e-c-j.bin"/>
 		<part crc="3173ea78" name="a-4d-c-j.bin"/>
 		<part crc="32a0a9a6" name="a-4e-c-j.bin"/>


### PR DESCRIPTION
Only missing kungfumd (US release by Data East), couldn't figure out the rom mapping easily, it's very different than the others. Might be able to figure out later.

MAME mappings referenced:

kungfub - https://github.com/mamedev/mame/blob/c624eb0102ce5db000811df84b5d1f9853770d96/src/mame/drivers/m62.cpp#L1317

kungfub2 - https://github.com/mamedev/mame/blob/c624eb0102ce5db000811df84b5d1f9853770d96/src/mame/drivers/m62.cpp#L1385

spartanx (Japanese version of Kung-Fu Master) - https://github.com/mamedev/mame/blob/c624eb0102ce5db000811df84b5d1f9853770d96/src/mame/drivers/m62.cpp#L1271