### PR TITLE
Fix alternative MRA MysticMarathon rbf tag

### DIFF
--- a/_alternatives/_Mystic Marathon/Mystic Marathon (prototype).mra
+++ b/_alternatives/_Mystic Marathon/Mystic Marathon (prototype).mra
@@ -14,7 +14,7 @@
   <setname>mysticm</setname>
   <parent>mysticm</parent>
   <mameversion>0222</mameversion>
-  <rbf>mysticm</rbf>
+  <rbf>MysticMarathon</rbf>
   <about></about>
 
   <resolution>15kHz</resolution>


### PR DESCRIPTION
I had forgotten to update this one too when I did the name change a long time ago.